### PR TITLE
Use TOOLCHAINS env var instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 ARCHS = armv7 arm64
-export TARGET_CC=/Library/Developer/Toolchains/Hikari.xctoolchain/usr/bin/clang
-export TARGET_CXX=/Library/Developer/Toolchains/Hikari.xctoolchain/usr/bin/clang++
+export TOOLCHAINS=Hikari
 include $(THEOS)/makefiles/common.mk
 
 TWEAK_NAME = MUGKit


### PR DESCRIPTION
A cleaner way of switching the toolchain w/ theos & xcrun